### PR TITLE
fix: align temporal object parsing behavior

### DIFF
--- a/src/plain-date-time.mjs
+++ b/src/plain-date-time.mjs
@@ -35,7 +35,20 @@ export class PlainDateTime {
     if (typeof thing === "string") {
       luxon = LuxonDateTime.fromISO(thing);
     } else {
-      luxon = LuxonDateTime.fromObject(thing);
+      ["year", "day", "month"].forEach((field) => {
+        if (thing[field] === undefined) {
+          throw new TypeError(`missing "${field}" calendar field`);
+        }
+      });
+      luxon = LuxonDateTime.fromObject({
+        year: thing.year,
+        month: thing.month,
+        day: thing.day,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+      }).set(thing);
     }
     const { year, month, day, hour, minute, second, millisecond } = luxon;
 

--- a/src/plain-date.mjs
+++ b/src/plain-date.mjs
@@ -27,6 +27,11 @@ export class PlainDate {
     if (typeof thing === "string") {
       luxon = LuxonDateTime.fromISO(thing);
     } else {
+      ["year", "day", "month"].forEach((field) => {
+        if (thing[field] === undefined) {
+          throw new TypeError(`missing "${field}" calendar field`);
+        }
+      });
       luxon = LuxonDateTime.fromObject(thing);
     }
     const { year, month, day } = luxon;

--- a/src/plain-time.mjs
+++ b/src/plain-time.mjs
@@ -27,7 +27,12 @@ export class PlainTime {
     if (typeof thing === "string") {
       luxon = LuxonDateTime.fromISO(thing);
     } else {
-      luxon = LuxonDateTime.fromObject(thing);
+      luxon = LuxonDateTime.fromObject({
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+      }).plus(thing);
     }
     const { hour, minute, second, millisecond } = luxon;
 

--- a/src/zoned-date-time.mjs
+++ b/src/zoned-date-time.mjs
@@ -9,8 +9,26 @@ export class ZonedDateTime {
       // return new ZonedDateTime(new Date(item).getTime(), timeZone)
     }
     const { timeZone, ...props } = item;
+    ["year", "day", "month"].forEach((field) => {
+      if (props[field] === undefined) {
+        throw new TypeError(`missing "${field}" calendar field`);
+      }
+    });
     const instant = Instant.from(
-      LuxonDateTime.fromObject(props, { zone: timeZone }).toISO()
+      LuxonDateTime.fromObject(
+        {
+          year: props.year,
+          month: props.month,
+          day: props.day,
+          hour: 0,
+          minute: 0,
+          second: 0,
+          millisecond: 0,
+        },
+        { zone: timeZone }
+      )
+        .set(props)
+        .toISO()
     );
 
     return new ZonedDateTime(instant.epochMilliseconds, timeZone);

--- a/test/plain-date-time.mjs
+++ b/test/plain-date-time.mjs
@@ -43,6 +43,40 @@ describe("PlainDateTime", function () {
       expect(dt.second).to.equal(0);
       expect(dt.millisecond).to.equal(0);
     });
+
+    it("should create a PlainDateTime from an object with default time fields", function () {
+      const dt = PlainDateTime.from({
+        year: 2023,
+        month: 6,
+        day: 6,
+        hour: 12,
+      });
+      expect(dt).to.be.an.instanceof(PlainDateTime);
+      expect(dt.year).to.equal(2023);
+      expect(dt.month).to.equal(6);
+      expect(dt.day).to.equal(6);
+      expect(dt.hour).to.equal(12);
+      expect(dt.minute).to.equal(0);
+      expect(dt.second).to.equal(0);
+      expect(dt.millisecond).to.equal(0);
+    });
+
+    it("should throw if an object is missing a required date field", function () {
+      expect(() => PlainDateTime.from({ second: 0 })).to.throw(
+        TypeError,
+        'missing "year" calendar field'
+      );
+      expect(() => PlainDateTime.from({ year: 2023, second: 0 })).to.throw(
+        TypeError,
+        'missing "day" calendar field'
+      );
+      expect(() =>
+        PlainDateTime.from({ year: 2023, month: 6, second: 0 })
+      ).to.throw(TypeError, 'missing "day" calendar field');
+      expect(() =>
+        PlainDateTime.from({ year: 2023, day: 6, second: 0 })
+      ).to.throw(TypeError, 'missing "month" calendar field');
+    });
   });
 
   describe("add", function () {

--- a/test/plain-date.mjs
+++ b/test/plain-date.mjs
@@ -49,6 +49,17 @@ describe("PlainDate", function () {
       expect(result.month).to.equal(6);
       expect(result.day).to.equal(1);
     });
+
+    it("should throw if an object is missing a required date field", function () {
+      expect(() => PlainDate.from({ month: 6, day: 6 })).to.throw(
+        TypeError,
+        'missing "year" calendar field'
+      );
+      expect(() => PlainDate.from({ year: 2023, month: 6 })).to.throw(
+        TypeError,
+        'missing "day" calendar field'
+      );
+    });
   });
 
   describe("add", function () {

--- a/test/plain-time.mjs
+++ b/test/plain-time.mjs
@@ -33,6 +33,24 @@ describe("PlainTime", function () {
       expect(time.second).to.equal(0);
       expect(time.millisecond).to.equal(0);
     });
+
+    it("should create a PlainTime object from an object with default time fields", function () {
+      const time = PlainTime.from({ second: 30 });
+
+      expect(time.hour).to.equal(0);
+      expect(time.minute).to.equal(0);
+      expect(time.second).to.equal(30);
+      expect(time.millisecond).to.equal(0);
+    });
+
+    it("should create a PlainTime object from an empty object", function () {
+      const time = PlainTime.from({});
+
+      expect(time.hour).to.equal(0);
+      expect(time.minute).to.equal(0);
+      expect(time.second).to.equal(0);
+      expect(time.millisecond).to.equal(0);
+    });
   });
 
   describe("add", function () {

--- a/test/zoned-date-time.mjs
+++ b/test/zoned-date-time.mjs
@@ -32,6 +32,47 @@ describe("ZonedDateTime", function () {
       expect(zonedDateTime.millisecond).to.equal(0);
       expect(zonedDateTime.timeZoneId).to.equal("America/New_York");
     });
+
+    it("should create a ZonedDateTime from an object with default time fields", function () {
+      const zonedDateTime = ZonedDateTime.from({
+        year: 2023,
+        month: 6,
+        day: 6,
+        hour: 12,
+        timeZone: "UTC",
+      });
+
+      expect(zonedDateTime).to.be.an.instanceof(ZonedDateTime);
+      expect(zonedDateTime.year).to.equal(2023);
+      expect(zonedDateTime.month).to.equal(6);
+      expect(zonedDateTime.day).to.equal(6);
+      expect(zonedDateTime.hour).to.equal(12);
+      expect(zonedDateTime.minute).to.equal(0);
+      expect(zonedDateTime.second).to.equal(0);
+      expect(zonedDateTime.millisecond).to.equal(0);
+      expect(zonedDateTime.timeZoneId).to.equal("UTC");
+    });
+
+    it("should throw if an object is missing a required date field", function () {
+      expect(() =>
+        ZonedDateTime.from({ seconds: 0, timeZone: "America/Sao_Paulo" })
+      ).to.throw(TypeError, 'missing "year" calendar field');
+      expect(() =>
+        ZonedDateTime.from({
+          year: 2023,
+          seconds: 0,
+          timeZone: "America/Sao_Paulo",
+        })
+      ).to.throw(TypeError, 'missing "day" calendar field');
+      expect(() =>
+        ZonedDateTime.from({
+          year: 2023,
+          day: 1,
+          seconds: 0,
+          timeZone: "America/Sao_Paulo",
+        })
+      ).to.throw(TypeError, 'missing "month" calendar field');
+    });
   });
 
   describe("getters", function () {


### PR DESCRIPTION
## Summary
- Align object parsing in `PlainTime`, `PlainDate`, `PlainDateTime`, and `ZonedDateTime` with native Temporal behavior
- Default omitted time fields to zero instead of inheriting Luxon/current clock values
- Require mandatory date fields for date-bearing object inputs and preserve Temporal-like missing-field errors
- Add regression tests for partial object inputs across the affected classes

## Verification
- `npm test`
